### PR TITLE
fix: close redis connections on unsubscribe (upstream #2917)

### DIFF
--- a/router/pkg/pubsub/redis/adapter.go
+++ b/router/pkg/pubsub/redis/adapter.go
@@ -107,7 +107,7 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, conf datasource.Subscri
 
 		err = sub.Close()
 		if err != nil {
-			log.Error(fmt.Sprintf("error closing connection to redis: %w", zap.Error(err)))
+			log.Error(fmt.Sprintf("error closing connection to redis: %v", zap.Error(err)))
 		}
 	}
 

--- a/router/pkg/pubsub/redis/adapter.go
+++ b/router/pkg/pubsub/redis/adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/wundergraph/cosmo/router/pkg/metric"
 
@@ -100,7 +101,10 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, conf datasource.Subscri
 	msgChan := sub.Channel()
 
 	cleanup := func() {
-		err := sub.PUnsubscribe(context.Background(), subConf.Channels...)
+		unsubCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		err := sub.PUnsubscribe(unsubCtx, subConf.Channels...)
 		if err != nil {
 			log.Error(fmt.Sprintf("error unsubscribing from redis for topics %v", subConf.Channels), zap.Error(err))
 		}

--- a/router/pkg/pubsub/redis/adapter.go
+++ b/router/pkg/pubsub/redis/adapter.go
@@ -100,9 +100,14 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, conf datasource.Subscri
 	msgChan := sub.Channel()
 
 	cleanup := func() {
-		err := sub.PUnsubscribe(ctx, subConf.Channels...)
+		err := sub.PUnsubscribe(context.Background(), subConf.Channels...)
 		if err != nil {
 			log.Error(fmt.Sprintf("error unsubscribing from redis for topics %v", subConf.Channels), zap.Error(err))
+		}
+
+		err = sub.Close()
+		if err != nil {
+			log.Error(fmt.Sprintf("error closing connection to redis: %w", zap.Error(err)))
 		}
 	}
 


### PR DESCRIPTION
Cherry-picks upstream wundergraph/cosmo#2917 onto our fork.

Closes the redis pub/sub connection on unsubscribe (`sub.Close()`), fixing the connection leak. Also gives the unsubscribe a fixed 1s timeout context.

Upstream PR: https://github.com/wundergraph/cosmo/pull/2917

🤖 Generated with [Claude Code](https://claude.com/claude-code)